### PR TITLE
chore(ratelimit): implement ratelimiting using bucket4j and a filter

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -36,6 +36,11 @@
 			<version>5.9.2</version>
 			<scope>test</scope>
 		</dependency>
+		<dependency>
+			<groupId>com.bucket4j</groupId>
+			<artifactId>bucket4j-core</artifactId>
+			<version>8.2.0</version>
+		</dependency>
 	</dependencies>
 
 	<build>

--- a/src/main/java/com/fpiacentini/challenge/filter/RateLimitFilter.java
+++ b/src/main/java/com/fpiacentini/challenge/filter/RateLimitFilter.java
@@ -1,0 +1,35 @@
+package com.fpiacentini.challenge.filter;
+
+import com.fpiacentini.challenge.ratelimit.BucketManager;
+import jakarta.servlet.Filter;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.ServletRequest;
+import jakarta.servlet.ServletResponse;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.HttpStatusCode;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+
+@Component
+public class RateLimitFilter extends OncePerRequestFilter {
+
+    @Autowired
+    BucketManager bucketManager;
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
+        if (!bucketManager.tryConsume()) {
+            response.setStatus(HttpStatus.TOO_MANY_REQUESTS.value());
+            response.setContentType("text/plain");
+            response.getWriter().append("Too many requests");
+            return;
+        }
+        filterChain.doFilter(request, response);
+    }
+}

--- a/src/main/java/com/fpiacentini/challenge/ratelimit/BucketManager.java
+++ b/src/main/java/com/fpiacentini/challenge/ratelimit/BucketManager.java
@@ -1,0 +1,28 @@
+package com.fpiacentini.challenge.ratelimit;
+
+import io.github.bucket4j.Bandwidth;
+import io.github.bucket4j.Bucket;
+import io.github.bucket4j.Refill;
+import org.springframework.context.annotation.Scope;
+import org.springframework.stereotype.Component;
+
+import java.time.Duration;
+
+@Component
+@Scope("singleton")
+public class BucketManager {
+
+    private final static int TOKENS_CAPACITY = 3;
+    private Bucket bucket;
+
+    public BucketManager(){
+        Refill refill = Refill.intervally(TOKENS_CAPACITY, Duration.ofMinutes(1));
+        Bandwidth limit = Bandwidth.classic(TOKENS_CAPACITY, refill);
+        Bucket bucket = Bucket.builder().addLimit(limit).build();
+        this.bucket = bucket;
+    }
+
+    public boolean tryConsume(){
+        return bucket.tryConsume(1);
+    }
+}


### PR DESCRIPTION
Implement ratelimiting using [bucket4j](https://github.com/bucket4j/bucket4j) and a OncePerRequestFilter

Using [intervally](https://github.com/bucket4j/bucket4j/blob/2232d845e36137f5606dcbd7361d5bb7ed321bb5/asciidoc/src/main/docs/asciidoc/basic/concepts.adoc) refill mode.

```
This type of refill regenerates tokens in an interval manner. "Interval" in opposite to "greedy" will wait until the whole period will be elapsed before regenerating the whole amount of tokens.

```