### PR TITLE
Feat/external webserver

### DIFF
--- a/scripts/external-service/README.md
+++ b/scripts/external-service/README.md
@@ -1,0 +1,43 @@
+# External service
+
+This folder contains a Python 3 script to run a simple webserver.
+
+This webserver will expose an api on port 8081.
+
+Only one GET endpoint will be exposed.
+
+This endpoint will respond a random integer number between 0 and 100.
+
+## Prerequisites
+- Python 3.8.2 or above
+
+
+## Running locally
+To run the webserver locally, execute the following:
+```
+python3 external-webserver.py
+```
+
+To stop the webserver, simply press CTRL + C.
+
+## Example
+
+```aidl
+
+$ python3 external-webserver.py
+Percentage Web server is running http://localhost:8081
+127.0.0.1 - - [12/Mar/2023 20:09:00] "GET / HTTP/1.1" 200 -
+127.0.0.1 - - [12/Mar/2023 20:09:00] Response: {"value": 2}
+127.0.0.1 - - [12/Mar/2023 20:11:28] "GET / HTTP/1.1" 200 -
+127.0.0.1 - - [12/Mar/2023 20:11:28] Response: {"value": 58}
+127.0.0.1 - - [12/Mar/2023 20:11:29] "GET / HTTP/1.1" 200 -
+127.0.0.1 - - [12/Mar/2023 20:11:29] Response: {"value": 41}
+127.0.0.1 - - [12/Mar/2023 20:11:29] "GET / HTTP/1.1" 200 -
+127.0.0.1 - - [12/Mar/2023 20:11:29] Response: {"value": 55}
+127.0.0.1 - - [12/Mar/2023 20:11:30] "GET / HTTP/1.1" 200 -
+127.0.0.1 - - [12/Mar/2023 20:11:30] Response: {"value": 55}
+127.0.0.1 - - [12/Mar/2023 20:11:30] "GET / HTTP/1.1" 200 -
+127.0.0.1 - - [12/Mar/2023 20:11:30] Response: {"value": 44}
+^C
+Server stopped.
+```

--- a/scripts/external-service/README.md
+++ b/scripts/external-service/README.md
@@ -25,7 +25,7 @@ To stop the webserver, simply press CTRL + C.
 ```aidl
 
 $ python3 external-webserver.py
-Percentage Web server is running http://localhost:8081
+Percentage Web server is running on http://localhost:8081
 127.0.0.1 - - [12/Mar/2023 20:09:00] "GET / HTTP/1.1" 200 -
 127.0.0.1 - - [12/Mar/2023 20:09:00] Response: {"value": 2}
 127.0.0.1 - - [12/Mar/2023 20:11:28] "GET / HTTP/1.1" 200 -

--- a/scripts/external-service/external-webserver.py
+++ b/scripts/external-service/external-webserver.py
@@ -18,7 +18,7 @@ class PercentageServer (BaseHTTPRequestHandler):
         self.log_message(f"Response: {json_data}")
 if __name__ == "__main__":
     webServer = HTTPServer ((hName, Port), PercentageServer)
-    print("Percentage Web server is running http://%s:%s" % (hName, Port))
+    print("Percentage Web server is running on http://%s:%s" % (hName, Port))
 
     try:
         webServer.serve_forever()

--- a/scripts/external-service/external-webserver.py
+++ b/scripts/external-service/external-webserver.py
@@ -10,12 +10,12 @@ class PercentageServer (BaseHTTPRequestHandler):
         data = {
             "value" : percentage
         }
-
+        json_data = json.dumps(data)
         self.send_response(200)
         self.send_header("Content-type", "application/json")
         self.end_headers()
-        self.wfile.write(bytes(json.dumps(data), "utf-8"))
-        self.log_message(f"Response: {json.dumps(data)}")
+        self.wfile.write(bytes(json_data, "utf-8"))
+        self.log_message(f"Response: {json_data}")
 if __name__ == "__main__":
     webServer = HTTPServer ((hName, Port), PercentageServer)
     print("Percentage Web server is running http://%s:%s" % (hName, Port))

--- a/scripts/external-service/external-webserver.py
+++ b/scripts/external-service/external-webserver.py
@@ -1,0 +1,29 @@
+from http.server import BaseHTTPRequestHandler, HTTPServer
+import random
+import json
+
+hName = "localhost"
+Port = 8081
+class PercentageServer (BaseHTTPRequestHandler):
+    def do_GET (self):
+        percentage = random.randint(0, 100)
+        data = {
+            "value" : percentage
+        }
+
+        self.send_response(200)
+        self.send_header("Content-type", "application/json")
+        self.end_headers()
+        self.wfile.write(bytes(json.dumps(data), "utf-8"))
+        self.log_message(f"Response: {json.dumps(data)}")
+if __name__ == "__main__":
+    webServer = HTTPServer ((hName, Port), PercentageServer)
+    print("Percentage Web server is running http://%s:%s" % (hName, Port))
+
+    try:
+        webServer.serve_forever()
+    except KeyboardInterrupt:
+        pass
+
+    webServer.server_close()
+    print("\nServer stopped.")


### PR DESCRIPTION
Create a simple python webserver to simulate external service
This webserver will expose an api on port 8081.
Only one GET endpoint will be exposed.
This endpoint will respond a random integer number between 0 and 100.
